### PR TITLE
#432 : 김혜원 : joinedgroup list 보기 (그룹장만, penalty 정보도 함께) : joinedgroup list 보기 (studygroup 오픈 전, 후에 따른 penalty 정보도 포함)

### DIFF
--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedUserInfo.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedUserInfo.java
@@ -10,11 +10,9 @@ import lombok.*;
 public class JoinedUserInfo {
     private String group_id;
     private String user_id;
-    private String role;
     private String joinstatus;
     private int submission_cnt;
     private String name;
     private String nickname;
-    private String email;
     private String profile_img;
 }

--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupController.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupController.java
@@ -2,6 +2,8 @@ package com.example.studyproject.joinedgroup;
 
 import com.example.studyproject.member.MemberService;
 import com.example.studyproject.member.Member;
+import com.example.studyproject.penaltylog.PenaltylogFetcher;
+import com.example.studyproject.penaltylog.PenaltylogService;
 import com.example.studyproject.studygroup.StudyGroup;
 import com.example.studyproject.studygroup.StudyGroupService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -30,6 +33,7 @@ import java.util.Map;
  * @ 2024.05.19     김혜원        그룹 상태 변경
  * @ 2024.05.27     김혜원        get 메서드 추가
  * @ 2024.06.10     김혜원        joinedgroup 타입 바꾸기
+ * @ 2024.11.09     김혜원        joinedlist 가져오기
  */
 
 @RestController
@@ -43,11 +47,18 @@ public class JoinedgroupController {
     private MemberService memberService;
 
     @Autowired
-    private StudyGroupService sturyGroupService;
+    private StudyGroupService studyGroupService;
+
+    @Autowired
+    private PenaltylogService penaltylogService;
 
     // log4j2 로그 찍기
     private static final Logger LOGGER = LogManager.getLogger(JoinedgroupController.class);
 
+    public static final String JOIN_REQUEST = "PERM10"; // 가입대기
+    public static final String JOIN_APPROVED = "PERM20"; // 가입승인
+    public static final String RECRUITING = "STAT10"; // 모집중
+    public static final String IN_PROGRESS = "STAT20"; // 진행중
 
     @GetMapping("/joinedList")
     public Map selectJoinedList(HttpServletRequest request){
@@ -116,8 +127,9 @@ public class JoinedgroupController {
      * @param status - 수정할 값
      */
     @PutMapping("/updateStatus/{status}")
-    public void updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
-        LOGGER.info("================ joinedgroup join");
+    public Map updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
+        Map map = new HashMap();
+        LOGGER.info("================ joinedgroup update");
         Joinedgroup joinedgroupVo = joinedgroupService.getByUserIdAndGroupId(vo.getUser_id(), vo.getGroup_id());
         // 나중 : status가 code 테이블에 있는지 검사
 
@@ -125,9 +137,8 @@ public class JoinedgroupController {
 
         // 값이 있을 때에만 수정 가능
         if(joinedgroupVo != null){
-            success = joinedgroupService.updateJoinedStatus(vo, status);
+            success = joinedgroupService.updateJoinedStatus(joinedgroupVo.getGroup_id(), joinedgroupVo.getUser_id(), status);
         }
-
 
         if(success){
             LOGGER.info("================ join update success");
@@ -135,6 +146,9 @@ public class JoinedgroupController {
             LOGGER.info("================ join update failed");
         }
 
+        map.put("success", success);
+
+        return map;
     }
 
     // 조건에 따른 목록보기
@@ -155,7 +169,12 @@ public class JoinedgroupController {
     }
 
     /**
-     * 그룹장 신청한 목록 보기
+     * 그룹 오너가 해당 그룹의 멤버 목록과 관련된 정보를 조회하는 API입니다.
+     *
+     * 1. 로그인된 사용자의 ID가 해당 그룹의 오너와 일치하는지 확인합니다.
+     * 2. 그룹이 오픈 전인지 후인지 확인한 후, 그에 따라 다른 데이터를 반환합니다.
+     * - 오픈 전인 경우: 가입 신청 및 승인된 목록을 반환합니다.
+     * - 오픈 후인 경우: 그룹 멤버들의 패널티 정보와 관련된 데이터를 반환합니다.
      * @param request
      * @param group_id
      * @return
@@ -166,23 +185,29 @@ public class JoinedgroupController {
         Map map = new HashMap();
         if (session == null) {
             return null;
-        } else {
-            String loginId = (String) session.getAttribute("loginId");
-
-            ArrayList<JoinedUserInfo> list = new ArrayList<JoinedUserInfo>();
-
-            // 1. userId가 groupId랑 같은지 비교
-            StudyGroup studyGroup= sturyGroupService.selectStudyGroup(group_id);
-
-            // 2. 맞다면 목록 가져오기
-            if(loginId.equals(studyGroup.getLeader_id())){
-                list = joinedgroupService.selectListByGroupId(group_id);
-
-            }
-            LOGGER.info("================ " + list.size());
-            map.put("managedGroupsList", list);
         }
+        String loginId = (String) session.getAttribute("loginId");
+        // 1. userId가 groupId랑 같은지 비교
+        StudyGroup studyGroup= studyGroupService.selectStudyGroup(group_id);
+
+        if(studyGroup == null || !loginId.equals(studyGroup.getLeader_id())){
+            return map;  // 그룹 정보가 없거나, 로그인 ID가 그룹장과 일치하지 않으면 빈 맵 반환
+        }
+
+        // 2. 맞다면 목록 가져오기
+        if(studyGroup.getStatus().equals(RECRUITING)){ // 2-1. 오픈 전이라면
+            // (1) 가입 신청한 목록 PERM10
+            List<JoinedUserInfo> joinRequestList = joinedgroupService.selectListByGroupId(group_id, JOIN_REQUEST);
+            // (2) 가입 승인된 목록 PERM20
+            List<JoinedUserInfo> joinApprovedList = joinedgroupService.selectListByGroupId(group_id, JOIN_APPROVED);
+
+            map.put("joinRequestList", joinRequestList);
+            map.put("joinApprovedList", joinApprovedList);
+        } else if(studyGroup.getStatus().equals(IN_PROGRESS)){ // 2-2. 모집중이라면
+            List<PenaltylogFetcher> penaltylogInfoList = penaltylogService.getPanaltylogByGroupIdAndUserId(group_id);
+            map.put("penaltylogInfoList", penaltylogInfoList);
+        }
+
         return map;
     }
-
 }

--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupController.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupController.java
@@ -127,9 +127,8 @@ public class JoinedgroupController {
      * @param status - 수정할 값
      */
     @PutMapping("/updateStatus/{status}")
-    public Map updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
-        Map map = new HashMap();
-        LOGGER.info("================ joinedgroup update");
+    public void updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
+        LOGGER.info("================ joinedgroup join");
         Joinedgroup joinedgroupVo = joinedgroupService.getByUserIdAndGroupId(vo.getUser_id(), vo.getGroup_id());
         // 나중 : status가 code 테이블에 있는지 검사
 
@@ -137,8 +136,9 @@ public class JoinedgroupController {
 
         // 값이 있을 때에만 수정 가능
         if(joinedgroupVo != null){
-            success = joinedgroupService.updateJoinedStatus(joinedgroupVo.getGroup_id(), joinedgroupVo.getUser_id(), status);
+            success = joinedgroupService.updateJoinedStatus(vo, status);
         }
+
 
         if(success){
             LOGGER.info("================ join update success");
@@ -146,9 +146,6 @@ public class JoinedgroupController {
             LOGGER.info("================ join update failed");
         }
 
-        map.put("success", success);
-
-        return map;
     }
 
     // 조건에 따른 목록보기

--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupDao.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupDao.java
@@ -44,6 +44,6 @@ public interface JoinedgroupDao {
     // 그룹아이디로 리스트 사이즈 체크
     int selectJoinedListSize(String group_id);
 
-    // groupId로 불러오기
-    ArrayList<JoinedUserInfo> selectJoinedListByGroupId(String groupId);
+    // 그룹 ID와 가입 상태에 따라 joinedgroup 목록을 조회합니다.
+    ArrayList<JoinedUserInfo> selectJoinedListByGroupId(String group_id,  String joinStatus);
 }

--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupService.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @Class Name : JoinedgroupService.java
@@ -26,10 +27,6 @@ public class JoinedgroupService {
     public static final Logger LOGGER = LogManager.getLogger(JoinedgroupService.class);
 
     private final JoinedgroupDao joinedgroupDao;
-
-    public static final String JOIN_REQUEST = "PERM10"; // 가입대기
-    public static final String JOIN_APPROVED = "PERM20"; // 가입승인
-    public static final String JOIN_REJECTED = "PERM30"; // 가입승인
 
     public JoinedgroupService(JoinedgroupDao joinedgroupDao){
         this.joinedgroupDao = joinedgroupDao;
@@ -79,17 +76,11 @@ public class JoinedgroupService {
     /**
      * 그룹 상태 변경
      */
-    public boolean updateJoinedStatus(String group_id, String user_id, String status){
-        if(!isValidStatus(status)){
-            return false;
-        }
+    public boolean updateJoinedStatus(Joinedgroup vo, String status){
+        vo.setJoinstatus(status);
 
-        Joinedgroup joinedgroup = new Joinedgroup();
-        joinedgroup.setGroup_id(group_id);
-        joinedgroup.setUser_id(user_id);
-        joinedgroup.setJoinstatus(status);
+        return joinedgroupDao.updateJoinedStatus(vo);
 
-        return joinedgroupDao.updateJoinedStatus(joinedgroup);
     }
 
     /**
@@ -116,10 +107,4 @@ public class JoinedgroupService {
     public ArrayList<JoinedUserInfo> selectListByGroupId(String group_id, String joinStatus) {
         return joinedgroupDao.selectJoinedListByGroupId(group_id, joinStatus);
     }
-
-    // 주어진 status 값이 유효한 값인지 확인합니다. (유효하면 true, 그렇지 않다면 false)
-    private boolean isValidStatus(String status) {
-        return JOIN_REQUEST.equals(status) || JOIN_APPROVED.equals(status) || JOIN_REJECTED.equals(status);
-    }
-
 }

--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupService.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupService.java
@@ -27,6 +27,10 @@ public class JoinedgroupService {
 
     private final JoinedgroupDao joinedgroupDao;
 
+    public static final String JOIN_REQUEST = "PERM10"; // 가입대기
+    public static final String JOIN_APPROVED = "PERM20"; // 가입승인
+    public static final String JOIN_REJECTED = "PERM30"; // 가입승인
+
     public JoinedgroupService(JoinedgroupDao joinedgroupDao){
         this.joinedgroupDao = joinedgroupDao;
     }
@@ -75,11 +79,17 @@ public class JoinedgroupService {
     /**
      * 그룹 상태 변경
      */
-    public boolean updateJoinedStatus(Joinedgroup vo, String status){
-        vo.setJoinstatus(status);
+    public boolean updateJoinedStatus(String group_id, String user_id, String status){
+        if(!isValidStatus(status)){
+            return false;
+        }
 
-        return joinedgroupDao.updateJoinedStatus(vo);
+        Joinedgroup joinedgroup = new Joinedgroup();
+        joinedgroup.setGroup_id(group_id);
+        joinedgroup.setUser_id(user_id);
+        joinedgroup.setJoinstatus(status);
 
+        return joinedgroupDao.updateJoinedStatus(joinedgroup);
     }
 
     /**
@@ -103,7 +113,13 @@ public class JoinedgroupService {
     }
 
     // 그룹아이디로 목록보기
-    public ArrayList<JoinedUserInfo> selectListByGroupId(String group_id) {
-        return joinedgroupDao.selectJoinedListByGroupId(group_id);
+    public ArrayList<JoinedUserInfo> selectListByGroupId(String group_id, String joinStatus) {
+        return joinedgroupDao.selectJoinedListByGroupId(group_id, joinStatus);
     }
+
+    // 주어진 status 값이 유효한 값인지 확인합니다. (유효하면 true, 그렇지 않다면 false)
+    private boolean isValidStatus(String status) {
+        return JOIN_REQUEST.equals(status) || JOIN_APPROVED.equals(status) || JOIN_REJECTED.equals(status);
+    }
+
 }

--- a/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogDao.java
+++ b/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogDao.java
@@ -32,5 +32,7 @@ public interface PenaltylogDao {
     // penaltylog 추가 유효성 검사
     boolean penaltyLogMultiChk(String group_id, String user_id, String penalty_round);
 
+    // 그룹 ID에 대한 penaltylog, member, joinedgroup에 대한 정보를 조회합니다.
+    List<PenaltylogFetcher> selectPenaltylogWithJoinedgroup(String group_id);
 }
 

--- a/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogFetcher.java
+++ b/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogFetcher.java
@@ -1,0 +1,21 @@
+package com.example.studyproject.penaltylog;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PenaltylogFetcher {
+    private String user_id;
+    private String name;
+    private String nickname;
+    private String profile_img;
+    private String group_id;
+    private int submission_cnt;
+    private List<PenaltylogSummary> penaltylogList;
+
+}

--- a/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogService.java
+++ b/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogService.java
@@ -137,4 +137,17 @@ public class PenaltylogService {
 //		return success;
 //	}
 
+	// 주어진 그룹 ID에 대한 penaltylog, member, joinedgroup 정보를 조회하여 반환
+	public List<PenaltylogFetcher> getPanaltylogByGroupIdAndUserId(String group_id){
+		List<PenaltylogFetcher> penaltylogInfoList = new ArrayList<>();
+
+		try{
+			penaltylogInfoList = penaltyLogDao.selectPenaltylogWithJoinedgroup(group_id);
+		} catch (Exception e){
+			e.printStackTrace();
+		}
+
+		return penaltylogInfoList;
+	}
+
 }

--- a/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogSummary.java
+++ b/Backend/src/main/java/com/example/studyproject/penaltylog/PenaltylogSummary.java
@@ -1,0 +1,13 @@
+package com.example.studyproject.penaltylog;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PenaltylogSummary {
+    private String logcontent;
+    private String penalty_round;
+}

--- a/Backend/src/main/resources/sqlMapper/joinedgroup/JoinedgroupManage_SQL.xml
+++ b/Backend/src/main/resources/sqlMapper/joinedgroup/JoinedgroupManage_SQL.xml
@@ -104,22 +104,21 @@
 		AND group_id = #{group_id}
 	</select>
 
-    <!-- groulId로 joindgroup list 검색  -->
+    <!-- 그룹ID(group_id)와 가입 상태(joinstatus)에 따른 joinedgroup 목록을 조회 -->
     <select id="selectJoinedListByGroupId" resultType="com.example.studyproject.joinedgroup.JoinedUserInfo">
         SELECT
             j.group_id,
             j.user_id,
-            j.role,
             j.joinstatus,
             j.submission_cnt,
             m.name,
             m.nickname,
-            m.email,
             m.profile_img
         FROM joinedgroup j
         JOIN member m ON j.user_id = m.user_id
         WHERE 1=1
         AND j.group_id = #{group_id}
-        AND j.role != 'ROLE10'
+        AND j.joinstatus = #{joinStatus}
+        ORDER BY nickname
     </select>
 </mapper>

--- a/Backend/src/main/resources/sqlMapper/penaltylog/PenaltyLogManage_SQL.xml
+++ b/Backend/src/main/resources/sqlMapper/penaltylog/PenaltyLogManage_SQL.xml
@@ -115,4 +115,47 @@
           and user_id = #{user_id}
           and penalty_round = #{penalty_round}
     </select>
+
+    <!--
+      'selectPenaltylogWithJoinedgroup' 쿼리: 특정 그룹에 대한 penaltylog를 조회하는 쿼리
+      penaltylog 테이블과 joinedgroup 테이블, member 테이블을 LEFT JOIN하여,
+      특정 그룹에 대한 penaltylog와 함께 그룹원에 대한 정보(이름, 닉네임, 프로필 이미지 등)도 함께 반환
+    -->
+    <!-- penaltylog.xml -->
+    <select id="selectPenaltylogWithJoinedgroup" resultMap="penaltylogFetcherResultMap">
+        SELECT
+            p.user_id,
+            p.group_id,
+            p.logcontent,
+            p.penalty_round,
+            j.submission_cnt,
+            m.name,
+            m.nickname,
+            m.profile_img
+        FROM penaltylog p
+        LEFT JOIN joinedgroup j ON p.user_id = j.user_id AND p.group_id = j.group_id
+        LEFT JOIN member m ON p.user_id = m.user_id
+        WHERE p.group_id = #{group_id}
+        ORDER BY m.nickname
+    </select>
+
+    <!--
+        penaltylogFetcherResultMap: SQL 쿼리 결과를 객체에 매핑하는 결과 맵
+    -->
+    <resultMap id="penaltylogFetcherResultMap" type="com.example.studyproject.penaltylog.PenaltylogFetcher">
+        <!-- PenaltylogFetcher 필드 매핑 -->
+        <result property="user_id" column="user_id"/>
+        <result property="group_id" column="group_id"/>
+        <result property="name" column="name"/>
+        <result property="nickname" column="nickname"/>
+        <result property="profile_img" column="profile_img"/>
+        <result property="submission_cnt" column="submission_cnt"/>
+
+        <!-- PenaltylogSummary 리스트 매핑 -->
+        <collection property="penaltylogList" ofType="com.example.studyproject.penaltylog.PenaltylogSummary">
+            <result property="logcontent" column="logcontent"/>
+            <result property="penalty_round" column="penalty_round"/>
+        </collection>
+    </resultMap>
+
 </mapper>


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> '#이슈번호 문제내용' 과 같은 형식으로 작성해주세요.
* #342  joinedgroup list 보기
> 버그 수정일 시 빠른 확인을 위해 Label > Bugs 선택해주세요.
<br/>

## 어떻게 해결했나요?
> 이번 PR의 작업 내용을 간략히 설명해주세요. (이미지 및 파일 첨부 (선택))
*

<br/>

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
```
public static final String JOIN_REQUEST = "PERM10"; // 가입대기
    public static final String JOIN_APPROVED = "PERM20"; // 가입승인
    public static final String RECRUITING = "STAT10"; // 모집중
    public static final String IN_PROGRESS = "STAT20"; // 진행중
```
`String`으로 비교하는 것보다는, 안정성을 위해 `final`로 선언하여 비교하는 방식으로 구현했습니다. 
하지만 `final`보다는 `enum` 방식을 사용하는 것이 더 적합할 수 있으므로, 이 부분은 회의에서 논의해보는 것이 좋겠습니다.

https://limkydev.tistory.com/66
enum을 사용할 경우, 클래스의 타입을 전반적으로 수정해야 합니다.

<br/><br/><br/>

```
public class PenaltylogFetcher {
    private String user_id;
    private String name;
    private String nickname;
    private String profile_img;
    private String group_id;
    private int submission_cnt;
    private List<PenaltylogSummary> penaltylogList;

}
```
![image](https://github.com/user-attachments/assets/a69ac5b2-5bcd-455c-b4e8-50a99e5b6117)
이렇게 객체를 가져오도록 구현하였으며, 한 사용자당 여러 개의 penaltylog를 가져올 수 있도록 처리하였습니다.


