### PR TITLE
#348 : 김혜원 : joinedgroup update 리팩토링 : joinedgroup update 리팩토링

### DIFF
--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupController.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupController.java
@@ -10,10 +10,13 @@ import org.apache.ibatis.annotations.Update;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -116,25 +119,25 @@ public class JoinedgroupController {
      * @param status - 수정할 값
      */
     @PutMapping("/updateStatus/{status}")
-    public void updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
+    public ResponseEntity<Map<String, Object>> updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
+        Map map = new HashMap();
         LOGGER.info("================ joinedgroup join");
         Joinedgroup joinedgroupVo = joinedgroupService.getByUserIdAndGroupId(vo.getUser_id(), vo.getGroup_id());
         // 나중 : status가 code 테이블에 있는지 검사
-
         boolean success = false;
 
         // 값이 있을 때에만 수정 가능
         if(joinedgroupVo != null){
-            success = joinedgroupService.updateJoinedStatus(vo, status);
+            success = joinedgroupService.updateJoinedStatus(joinedgroupVo.getGroup_id(),joinedgroupVo.getUser_id(), status);
         }
-
 
         if(success){
             LOGGER.info("================ join update success");
+            return ResponseEntity.ok(Collections.singletonMap("success", true));
         } else {
             LOGGER.info("================ join update failed");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.singletonMap("success", false));
         }
-
     }
 
     // 조건에 따른 목록보기

--- a/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupService.java
+++ b/Backend/src/main/java/com/example/studyproject/joinedgroup/JoinedgroupService.java
@@ -31,6 +31,10 @@ public class JoinedgroupService {
         this.joinedgroupDao = joinedgroupDao;
     }
 
+    public static final String JOIN_REQUEST = "PERM10"; // 가입대기
+    public static final String JOIN_APPROVED = "PERM20"; // 가입승인
+    public static final String JOIN_REJECTED = "PERM30"; // 가입승인
+
     // 사용자별 가입한 그룹 목록
     ArrayList<Joinedgroup> selectJoinedList(String user_id){
         return joinedgroupDao.selectJoinedList(user_id);
@@ -72,14 +76,17 @@ public class JoinedgroupService {
         return joinedgroupDao.deleteJoinedgroup(user_id, group_id);
     }
   
-    /**
-     * 그룹 상태 변경
-     */
-    public boolean updateJoinedStatus(Joinedgroup vo, String status){
-        vo.setJoinstatus(status);
+    // 그룹 상태 변경
+    public boolean updateJoinedStatus(String group_id, String user_id, String status){
+        if(!isValidStatus(status)){
+            return false;
+        }
+        Joinedgroup joinedgroup = new Joinedgroup();
+        joinedgroup.setGroup_id(group_id);
+        joinedgroup.setUser_id(user_id);
+        joinedgroup.setJoinstatus(status);
 
-        return joinedgroupDao.updateJoinedStatus(vo);
-
+        return joinedgroupDao.updateJoinedStatus(joinedgroup);
     }
 
     /**
@@ -105,5 +112,10 @@ public class JoinedgroupService {
     // 그룹아이디로 목록보기
     public ArrayList<JoinedUserInfo> selectListByGroupId(String group_id) {
         return joinedgroupDao.selectJoinedListByGroupId(group_id);
+    }
+
+    // 주어진 status 값이 유효한 값인지 확인합니다. (유효하면 true, 그렇지 않다면 false)
+    private boolean isValidStatus(String status) {
+        return JOIN_REQUEST.equals(status) || JOIN_APPROVED.equals(status) || JOIN_REJECTED.equals(status);
     }
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> '#이슈번호 문제내용' 과 같은 형식으로 작성해주세요.
* #348 
> 버그 수정일 시 빠른 확인을 위해 Label > Bugs 선택해주세요.
<br/>

## 어떻게 해결했나요?
> 이번 PR의 작업 내용을 간략히 설명해주세요. (이미지 및 파일 첨부 (선택))
```
public static final String JOIN_REQUEST = "PERM10"; // 가입대기
public static final String JOIN_APPROVED = "PERM20"; // 가입승인
public static final String JOIN_REJECTED = "PERM30"; // 가입승인
```
로 유효성을 검사하였다 

![image](https://github.com/user-attachments/assets/95f8a173-445a-4e2e-bfc9-013f298ab3db)


<br/>

<br/>

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 

```
ResponseEntity를 사용하면 응답 상태 코드를 명확하게 설정할 수 있습니다. 
예를 들어, 성공적인 요청에 대해 ResponseEntity.ok()를 사용하고, 오류가 발생한 경우 ResponseEntity.status(HttpStatus.BAD_REQUEST)로 상태 코드를 설정할 수 있습니다.
Map은 단순히 데이터를 담는 컨테이너일 뿐이며, 상태 코드나 응답 헤더를 설정하는 데는 적합하지 않습니다.
```
위와 같은 이유로 
```
@PutMapping("/updateStatus/{status}")
    public ResponseEntity<Map<String, Object>> updateJoinStatus(@RequestBody Joinedgroup vo, @PathVariable("status") String status){
```
로 변경하였습니다.
앞으로 맡은 기능에 대해서는 가능한 한 ResponseEntity를 사용하여 응답 상태 코드와 헤더를 명확하게 설정하는 방식으로 개선해나가면 좋겠습니다.

https://tiqndjd12.tistory.com/268?category=781711

