### PR TITLE
#385 : 김혜원 : studylogs : 마이스터디 전체글, 내 글, 상세 글보기

### DIFF
--- a/Frontend/src/pages/mystudy/detail/MyStudyDetail.js
+++ b/Frontend/src/pages/mystudy/detail/MyStudyDetail.js
@@ -1,14 +1,55 @@
 import React, {useState} from 'react';
+import { Routes, Route  } from 'react-router-dom';
 import axios from "axios";
+import {Link} from 'react-router-dom'; 
+
 import MyStudyDetailHeader from "./MyStudyDetailHeader";
 import myStudyDetailHome from "./MyStudyDetailHome";
 import MyStudyDetailHome from "./MyStudyDetailHome";
 import Test from "../Test";
 import MyStudyDetailMyList from "./MyStudyDetailMyList";
 import MyStudyDetailGroupInfo from "./MyStudyDetailGroupInfo";
+import MyStudyDetailAllList from './MyStudyDetailAllList';
+import PostDetail from '../../studylogs/PostDetail';
 
-const MyStudyDetail = () => {
-    const [selectedContent, setSelectedContent] = useState([]);
+const MyStudyDetail = ({group_id, user_id}) => {
+    const [selectedContent, setSelectedContent] = useState('');
+
+    const [selectedPostId, setSelectedPostId] = useState('');
+    const [selectAuthorId, setSelectAuthorId] = useState('');
+
+    // 게시글 상세보기 클릭 시 호출되는 함수
+    const handlePostSelect = (postId, authorId, content) => {
+        setSelectedPostId(postId); 
+        setSelectAuthorId(authorId);
+        setSelectedContent(content);
+    };
+
+    // 탭 변경될 때, selectedPostId를 null로 설정하여 상세보기 내용 숨기기
+    const handleContentChange = (content) => {
+        setSelectedContent(content);
+        setSelectedPostId(null);
+    };
+
+    const BackButton = ({selectedContent, handleContentChange}) => {
+        if (selectedContent === 'StudyLogsAllList') {
+            return (
+                <Link to="/MyStudyDetail">
+                    <button onClick={() => handleContentChange('전체글 보기')}>뒤로가기</button>
+                </Link>
+            );
+        }
+    
+        if (selectedContent === 'StudyLogsMyList') {
+            return (
+                <Link to="/MyStudyDetail">
+                    <button onClick={() => handleContentChange('내 글 보기')}>뒤로가기</button>
+                </Link>
+            );
+        }
+    
+        return null;
+    };
 
     // const getGroupInfo = async(group_id, user_id) => {
     //     console.log('getGroupInfo');
@@ -44,12 +85,21 @@ const MyStudyDetail = () => {
         <div className={'common-content-container'}>
             <div className={'common-content'}>
                 <h1>나의 스터디</h1>
-                <MyStudyDetailHeader title="스터디명" onSelect={setSelectedContent}/>
+                <MyStudyDetailHeader title="스터디명" onSelect={handleContentChange}/>
 
 
                 <MyStudyDetailHome selectedContent={selectedContent}/>
-                <MyStudyDetailMyList selectedContent={selectedContent}/>
+                <MyStudyDetailMyList selectedContent={selectedContent} group_id={group_id} onPostSelect={(postId, authorId) => handlePostSelect(postId, authorId, 'StudyLogsMyList')} />
                 <MyStudyDetailGroupInfo selectedContent={selectedContent}/>
+                <MyStudyDetailAllList selectedContent={selectedContent} group_id={group_id} onPostSelect={(postId, authorId) => handlePostSelect(postId, authorId, 'StudyLogsAllList')} />
+               
+
+                {selectedPostId && (
+                    <div>
+                        <PostDetail selectedContent={selectedContent} postId={selectedPostId} authorId={selectAuthorId} />
+                        <BackButton selectedContent={selectedContent} handleContentChange={handleContentChange} />
+                    </div>
+                )}
             </div>
         </div>
 

--- a/Frontend/src/pages/mystudy/detail/MyStudyDetailAllList.js
+++ b/Frontend/src/pages/mystudy/detail/MyStudyDetailAllList.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+ 
+const MyStudyDetailAllList = ({ selectedContent, group_id, onPostSelect  }) => {
+    const [posts, setPosts] = useState([]); 
+
+    const getStudylogs = async (group_id) => {
+        try {
+            const response = await axios.get('http://localhost:3000/studylogs/selectAll', {
+                params: {
+                    group_id: '2410290001',  // group_id를 파라미터로 보내기
+                    user_id: null
+                },
+            });
+
+            if (response.status === 200) {
+                setPosts(response.data);            
+            } else {
+                console.error('Failed to fetch the post.');
+            }
+        } catch (error) {
+            console.error('API call failed:', error);
+        }
+    };
+
+    useEffect(() => {
+        if (selectedContent === '전체글 보기') {
+            getStudylogs(group_id);
+        }
+    }, [group_id, selectedContent]);
+
+    return (
+        <div className={'common-content'}>
+            {selectedContent === '전체글 보기' &&
+                <div>
+                    <p> 글ID, 제목, 글쓴이, 날짜 </p>
+
+                    {posts.length > 0 ? (
+                        posts.map((item) => (
+                            <div key={item.post_id}>
+
+                                <p>
+                                    {item.post_id}, 
+                                    {item.user_id}, 
+                                    <button onClick={() => onPostSelect(item.post_id, item.user_id)}>{item.title}</button>
+                                    
+                                    {item.create_date}
+                                </p>
+                            </div>
+                        ))
+                    ) : (
+                        <p>게시글이 없습니다.</p>
+                    )}
+                </div>
+            }
+        </div>
+    );
+}
+
+MyStudyDetailAllList.propTypes = {
+    selectedContent: PropTypes.string.isRequired,
+    group_id: PropTypes.string.isRequired,
+};
+
+export default MyStudyDetailAllList;

--- a/Frontend/src/pages/mystudy/detail/MyStudyDetailMyList.js
+++ b/Frontend/src/pages/mystudy/detail/MyStudyDetailMyList.js
@@ -1,16 +1,66 @@
-import React, {Component, useState} from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import axios from 'axios';
 
-const MyStudyDetailMyList = ({selectedContent}) => {
+const MyStudyDetailMyList = ({ selectedContent, group_id, onPostSelect }) => {
+    const [posts, setPosts] = useState([]);  
+    
+    const getStudylogs = async (group_id) => {
+        try {
+            const response = await axios.get('http://localhost:3000/studylogs/selectAll', {
+                params: {
+                    group_id: '2410290001',  // group_id를 파라미터로 보내기
+                    user_id: localStorage.getItem('user_id')
+                },
+            });
+
+            if (response.status === 200) {
+                setPosts(response.data);
+            } else {
+                console.error('Failed to fetch the post.');
+            }
+        } catch (error) {
+            console.error('API call failed:', error);
+        }
+    };
+
+    useEffect(() => {
+        if (selectedContent === '전체글 보기') {
+            getStudylogs(group_id);
+        }
+    }, [group_id, selectedContent]);
 
 
     return (
         <div className={'common-content'}>
-            {selectedContent === '내 글 보기' && <p>내글내글</p>}
+            {selectedContent === '내 글 보기' &&
+                <div>
+                    <p> 글ID, 제목, 글쓴이, 날짜 </p>
 
+                    {posts.length > 0 ? (
+                        posts.map((item) => (
+                            <div key={item.post_id}>
+                                <p>
+                                    {item.post_id},
+                                    {item.user_id},
+                                    <button onClick={() => onPostSelect(item.post_id, item.user_id)}>{item.title}</button>
+                                    {item.create_date}
+                                </p>
+                            </div>
+                        ))
+                    ) : (
+                        <p>게시글이 없습니다.</p>
+                    )}
+                </div>
+            }
         </div>
     );
 }
 
+MyStudyDetailMyList.propTypes = {
+    selectedContent: PropTypes.string.isRequired,
+    group_id: PropTypes.string.isRequired,
+    user_id: PropTypes.string.isRequired,
+};
 
 export default MyStudyDetailMyList;

--- a/Frontend/src/pages/studylogs/CreatePost.js
+++ b/Frontend/src/pages/studylogs/CreatePost.js
@@ -109,7 +109,7 @@ function CreatePost() {
     
     // studylog 정보 가져오는 useEffect
     useEffect(() => {
-        if (groupId && postId) {
+        if (postId) {
             axios.get(`http://localhost:3000/studylogs/studylogsdetail/${postId}`)
                 .then((response) => {
                     setIsEditMode(true);

--- a/Frontend/src/pages/studylogs/PostDetail.js
+++ b/Frontend/src/pages/studylogs/PostDetail.js
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import { Link } from 'react-router-dom'; 
+
+const PostDetail = ({ postId, authorId }) => {
+    const [postDetail, setPostDetail] = useState(null);
+    const [fileList, setFileList] = useState([]);
+
+    const currentUserId = localStorage.getItem('user_id'); 
+
+    const fetchPostDetail = async () => {
+        try {
+            const response = await axios.get(`http://localhost:3000/studylogs/studylogsdetail/${postId}`);
+            if (response.status === 200) {
+                setPostDetail(response.data.vo);
+                setFileList(response.data.fileList);
+            }
+        } catch (error) {
+            console.error('Failed to fetch post details', error);
+        }
+    };
+
+    useEffect(() => {
+        if(postId !== null){
+            fetchPostDetail();
+        }
+        
+    }, [postId]);
+
+    if (!postDetail) return <div>Loading...</div>;
+
+    return (
+        <div>
+            <h2>{postDetail.title}</h2>
+
+            <p>{postDetail.user_id}</p>
+            <p>{postDetail.create_date}</p>
+            <p>{postDetail.content}</p>
+
+            {/* 파일 */}
+            <div>
+                {fileList.map((file, index) => {
+                    if (file.fileType === 'KIND10') {
+                        return (
+                            <div key={index}>
+                                <img src={file.path} alt={file.fileName} width="400" />                               
+                            </div>
+                        );
+                    } else if (file.fileType === 'KIND20') {
+                        return (
+                            <div key={index}>
+                                <p>파일 이름 : {file.fileName}</p>
+                            </div>
+                        );
+                    }
+                    return null;
+                })}
+            </div>
+
+            {authorId === currentUserId && (
+                <Link to={`/createPost?postId=${postId}`}>
+                    <button>수정하기</button>
+                </Link>
+            )}
+            
+        </div>
+    );
+};
+
+PostDetail.propTypes = {
+    postId: PropTypes.string.isRequired,
+    authorId: PropTypes.string.isRequired,
+};
+
+export default PostDetail;


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> '#이슈번호 문제내용' 과 같은 형식으로 작성해주세요.
* #385 
> 버그 수정일 시 빠른 확인을 위해 Label > Bugs 선택해주세요.
<br/>

## 어떻게 해결했나요?
> 이번 PR의 작업 내용을 간략히 설명해주세요. (이미지 및 파일 첨부 (선택))
- 전체 글 보기 
- 내 글 보기 
- 상세보기 
① 제목, 유저아이디, 날짜, 내용, 이미지, 파일이름을 출력했습니다.
② 뒤로가기버튼이 있는데, 이 버튼을 누르면 뒤로 가진다.
(`전체글보기` → `상세보기` → `뒤로가기` 버튼 → `전체글보기` 로 이동
`내글보기` → `상세보기` → `뒤로가기` 버튼 → `내글보기` 로 이동)
③ 본인이 작성한 글에만 수정하기 버튼이 보임
<br/>

상세보기 페이지로 전환 시 탭을 유지하는 기능을 구현하기 어려웠습니다.
사용자가 "상세보기"를 클릭하면 setSelectedContent 값을 다른 항목으로 변경하고, post_id를 설정하여 상세보기 페이지를 표시합니다.
그리고 사용자가 다른 탭을 클릭하면 post_id가 null로 설정되어 상세보기가 숨겨지도록 구현하였습니다.

<br/>

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 

- 전체글보기
![image](https://github.com/user-attachments/assets/e39973ea-c033-404f-85af-bf49b39b1557)
<hr/>

<br/>

- 상세글보기

![image](https://github.com/user-attachments/assets/a0373263-8604-4357-99d3-d03e9658c518)
<hr/>

<br/>

- 본인이 작성한 글이 아니라면 수정 버튼 없음

![image](https://github.com/user-attachments/assets/64b7f165-a3c9-42db-ba5a-bb771c7c4ed7)

