### PR TITLE
#506, 507, 508, 512 : 김혜원 : 회원 탈퇴 처리 로직 추가(탈퇴 가능 여부 및 알 수 없음으로 변경)

### DIFF
--- a/Backend/src/main/java/com/example/studyproject/studygroup/StudyGroupDao.java
+++ b/Backend/src/main/java/com/example/studyproject/studygroup/StudyGroupDao.java
@@ -48,4 +48,7 @@ public interface StudyGroupDao {
 
 	// 제목 & (날짜 or 조회수) 조회
 	List<?> getStudyGroups(String title, Boolean isSortByViews, Boolean isSortByLatest);
+
+	// 회원 탈퇴 가능 여부 (운영중인 스터디의 개수 반환)
+	int countActiveStudyGroups(String user_id);
 }

--- a/Backend/src/main/java/com/example/studyproject/studygroup/StudyGroupService.java
+++ b/Backend/src/main/java/com/example/studyproject/studygroup/StudyGroupService.java
@@ -119,4 +119,9 @@ public class StudyGroupService {
 	public List<?> getStudyGroups(String title, Boolean isSortByViews, Boolean isSortByLatest){
 		return groupDao.getStudyGroups(title, isSortByViews, isSortByLatest);
 	}
+
+	// 회원 탈퇴 가능 여부 (해당 기간에 포함되는 데이터 개수 반환)
+	public int countActiveStudyGroups(String user_id){
+		return groupDao.countActiveStudyGroups(user_id);
+	}
 }

--- a/Backend/src/main/java/com/example/studyproject/studylogs/StudyLogsDao.java
+++ b/Backend/src/main/java/com/example/studyproject/studylogs/StudyLogsDao.java
@@ -17,6 +17,9 @@ public interface StudyLogsDao {
     // 결과물 업데이트
     void updateStudyLogs(StudyLogs vo);
 
+    // 회원 탈퇴 : 알수 없음으로 변경
+    void anonymizeUserId(String user_id);
+
 	  // 스터디로그 상세 조회
 	  StudyLogs selectStudyLogs(String post_id);
 

--- a/Backend/src/main/java/com/example/studyproject/studylogs/StudyLogsService.java
+++ b/Backend/src/main/java/com/example/studyproject/studylogs/StudyLogsService.java
@@ -77,6 +77,11 @@ public class StudyLogsService {
         studyLogsDao.updateStudyLogs(vo);
     }
 
+    // 회원 탈퇴 : 알수 없음으로 변경
+    public void anonymizeUserId(String user_id) {
+        studyLogsDao.anonymizeUserId(user_id);
+    }
+
     // 스터디로그 
     public ArrayList<StudyLogs> selectList() {
         return studyLogsDao.selectList();

--- a/Backend/src/main/resources/sqlMapper/member/MemberManage_SQL.xml
+++ b/Backend/src/main/resources/sqlMapper/member/MemberManage_SQL.xml
@@ -120,7 +120,11 @@
 	<!-- 회원 탈퇴 -->
 	<delete id="deleteMember">
 		DELETE FROM member
-		WHERE user_id = #{user_id}
+		WHERE user_id = #{user_id};
+		DELETE FROM joinedgroup
+		WHERE user_id = #{user_id};
+		DELETE FROM penaltylog
+		WHERE user_id = #{user_id};
 	</delete>
 
 

--- a/Backend/src/main/resources/sqlMapper/studygroup/StudyGroupManage_SQL.xml
+++ b/Backend/src/main/resources/sqlMapper/studygroup/StudyGroupManage_SQL.xml
@@ -129,7 +129,16 @@
 		WHERE 1=1
 		AND group_id = #{group_id};
 	</select>
-	
+
+	<!-- 회원 탈퇴 가능 여부  (운영중인 스터디의 개수 반환) -->
+	<select id="countActiveStudyGroups" resultType="int">
+		SELECT COUNT(*)
+		FROM studygroup
+		WHERE leader_id = #{user_id}
+		AND NOW() BETWEEN startdate AND enddate;
+	</select>
+
+
 	<!-- 조회수 업데이트 -->
 	<update id="updateViewCnt">
 		UPDATE studygroup

--- a/Backend/src/main/resources/sqlMapper/studylogs/StudyLogs_SQL.xml
+++ b/Backend/src/main/resources/sqlMapper/studylogs/StudyLogs_SQL.xml
@@ -57,6 +57,15 @@
         post_id = #{post_id}
     </update>
 
+    <!-- 회원 탈퇴 : 알수 없음으로 변경 -->
+    <update id="anonymizeUserId" >
+        UPDATE studylogs
+        SET
+        user_id = '알 수 없음'
+        WHERE
+        user_id = #{user_id}
+    </update>
+
     <!-- 스터디로그 전체 리스트 -->
     <select id = "selectList" resultType="com.example.studyproject.studylogs.StudyLogs">
         SELECT post_id

--- a/Frontend/src/pages/mypage/MemberOut.js
+++ b/Frontend/src/pages/mypage/MemberOut.js
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import {getIdFromLocalStorage} from '../Common.js';
 
 const MemberOut = () => {
     const [terms, setTerms] = useState('');
     const [agreed, setAgreed] = useState(false);
     const navigate = useNavigate();
-    const user_id = localStorage.getItem('loginId');
+    const user_id = getIdFromLocalStorage();
 
     useEffect(() => {
       // withdrawalTerms.txt 파일을 불러와서 내용을 상태에 저장
@@ -30,14 +31,24 @@ const MemberOut = () => {
                 }
             })
             .then(response => {
-                if(response.data) {
-                    alert('탈퇴가 완료되었습니다.');
+                console.log(response.data); 
+            
+                // 응답이 성공한 경우 (탈퇴 성공)
+                if (response.data.success) {
+                    alert(response.data.msg);  // TODO. sweet alert로 수정
                     localStorage.clear();
-                    navigate('/home');
+                    navigate('/'); 
                 } else {
-                    alert('비밀번호가 일치하지 않습니다.');
+                    // 탈퇴 불가능한 경우 (비밀번호 오류, 스터디 그룹이 존재하는 경우 등)
+                    alert(response.data.msg); // TODO. sweet alert로 수정
                 }
+            })
+            .catch(error => {
+                // 네트워크 오류 또는 서버 오류 처리
+                console.error('탈퇴 처리 중 오류 발생:', error);
+                alert('탈퇴 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
             });
+            
         } else {
             alert('탈퇴 약관에 동의해주세요.');
         }

--- a/Frontend/src/pages/studygroup/CreateStudygroup.js
+++ b/Frontend/src/pages/studygroup/CreateStudygroup.js
@@ -32,6 +32,12 @@ function CreateStudygroup() {
 
     useEffect(() => {
         if (isSubmitting) {
+            // TODO. SWEETALERT으로 변경하기
+            if (!window.confirm("스터디 생성 후 종료일까지 탈퇴 불가합니다. 진행할까요?")) {
+                console.log("스터디 생성 안 함");
+                return;
+            } 
+
             if (formData.title && formData.name && formData.mem_cnt && formData.chk_m && formData.chk_min_cnt && formData.startdate && formData.enddate && formData.study_desc) {
                 axios.post('http://localhost:3000/studygroup/createGroup', formData)
                     .then(response => {


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> '#이슈번호 문제내용' 과 같은 형식으로 작성해주세요.
*  #512
* #507 
* #506 
* #508 

> 버그 수정일 시 빠른 확인을 위해 Label > Bugs 선택해주세요.
<br/>

## 어떻게 해결했나요?
> 이번 PR의 작업 내용을 간략히 설명해주세요. (이미지 및 파일 첨부 (선택))

* ① 스터디 그룹 생성시 탈퇴 불가 안내 메시지 추가
* ② 탈퇴 - 운영중인 스터디가 있다면 탈퇴 불가능
* ③ 탈퇴 - 운영중인 스터디가 없다면 `member`, `프로필 사진`, `penaltylog`, `joinedgroup` 삭제 및 `studylogs` 알 수 없음으로 변경
* ④ 탈퇴 불가능 - user_id가 null이라 유효한 값을 보내서 해결 완료
* ⑤ 홈 화면으로 이동 안 됨 - `/home` 을 `/`으로 변경하여 navigate 수정
 

<br/>

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
* 

