### PR TITLE
#515 : 김혜원 : 스터디 그룹 생성시 startdate -1 처리 되는 오류 수정

### DIFF
--- a/Frontend/src/pages/studygroup/CreateStudygroup.js
+++ b/Frontend/src/pages/studygroup/CreateStudygroup.js
@@ -83,10 +83,13 @@ function CreateStudygroup() {
     // 날짜 포맷팅 함수 (LocalDateTime에 맞게 변환)
     const formatDateForServer = (date, isStart = true) => {
         const updatedDate = new Date(date);
-        updatedDate.setHours(isStart ? 0 : 23, isStart ? 0 : 59, isStart ? 0 : 59, isStart ? 0 : 999);
 
+        // 시작일과 종료일에 따라 시간 조정
+        updatedDate.setHours(isStart ? 0 : 23, isStart ? 0 : 59, isStart ? 0 : 59, isStart ? 0 : 999);
+        updatedDate.setHours(updatedDate.getHours() + 9); // 한국 표준시로 바꾸기
         // 'yyyy-MM-dd'T'HH:mm:ss' 포맷으로 반환
         return updatedDate.toISOString().slice(0, 19); // 마지막 초, 밀리초 제거
+
     };
 
     // 시작일 선택


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> '#이슈번호 문제내용' 과 같은 형식으로 작성해주세요.
* #515 
> 버그 수정일 시 빠른 확인을 위해 Label > Bugs 선택해주세요.
<br/>

## 어떻게 해결했나요?
> 이번 PR의 작업 내용을 간략히 설명해주세요. (이미지 및 파일 첨부 (선택))

* 날짜를 설정할 때, 기본적으로 시간대 차이로 인해 설정한 시간이 UTC 기준으로 처리되어 -9시간이 차감되어 날짜가 하루 더 일찍 들어가는 문제가 발생했다.
* 이 문제를 해결하기 위해, `Date` 객체의 시간을 한국 표준시(UTC+9)로 맞추기 위해 `setHours(updatedDate.getHours() + 9)`를 추가하여 시간을 수정했다.


<br/>

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
* 

