### PR TITLE
#537 : 김혜원 : studygroup : 스터디그룹 생성 내일부터 가능으로 변경

### DIFF
--- a/Frontend/src/pages/studygroup/CreateStudygroup.js
+++ b/Frontend/src/pages/studygroup/CreateStudygroup.js
@@ -186,7 +186,11 @@ function CreateStudygroup() {
                             selected={formData.startdate ? new Date(formData.startdate) : null}
                             onChange={startDateChange}
                             dateFormat="yyyy-MM-dd"
-                            minDate={new Date()}
+                            minDate={(() => {
+                                const today = new Date();
+                                today.setDate(today.getDate() + 1);
+                                return today;
+                            })()}
                         />
                     </div>
                     <div>


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> '#이슈번호 문제내용' 과 같은 형식으로 작성해주세요.
* #537 

> 버그 수정일 시 빠른 확인을 위해 Label > Bugs 선택해주세요.
<br/>

## 어떻게 해결했나요?
> 이번 PR의 작업 내용을 간략히 설명해주세요. (이미지 및 파일 첨부 (선택))
* 당일 날짜는 status 변경 안 됨
* 예를 들어 `2월 14일`에 스터디그룹의 시작일을 `2월 14일` 로 생성
* 스케줄러는 매일 00시에 수행하는데,
* 14일 스케줄러는 이미 돌았으므로, 2월 15일 00시가 되어야 운영중으로 변경됨
* 따라서 당일에 등록하면 status가 변경되지 않음
* 당일에 스터디 그룹 시작 가능하게 하는 것보다는 하루 뒤부터 생성 가능하도록 하는 것이 좋을 것 같음


<br/>

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
* 

